### PR TITLE
Show warnings when they are selected with the cursor

### DIFF
--- a/autobuild.py
+++ b/autobuild.py
@@ -65,7 +65,10 @@ class SublimeHaskellAutobuild(sublime_plugin.EventListener):
 
                 # Only deal with warnings if there are no errors
                 if not ERRORS.get(vid):
-                    hide_output(view)
+                    # We would like to close the panel here when moving away from a warning region,
+                    #     hide_output(view)
+                    # but does not seem to work as it closes *the active panel* (e.g. also find).
+                    # So the user has to close it manually with ESC for now.
                     warning = WARNINGS.get(vid, {}).get(lineno)
                     if warning:
                         write_output(view, unicode(warning), cabal_project_dir)
@@ -207,8 +210,16 @@ def write_output(view, text, cabal_project_dir):
     output_view.set_read_only(True)
     # Show the results panel:
     view.window().run_command('show_panel', {'panel': 'output.' + ERROR_PANEL_NAME})
+    print "  show view", view
+    # view.window().run_command('show_panel', {'panel': 'output.gaga'})
 
 def hide_output(view):
+    # TODO The 'panel' key doesn't appear in the API; most probably, it is ignored,
+    #      and simply the current panel is hidden.
+    # In theory, this should work:
+    #     run_command('show_panel', {'panel': 'output.' + ERROR_PANEL_NAME, 'toggle': True})
+    # but 'toggle' doesn't seem to work on output panels (it works on the 'console' panel).
+    # There doesn't currently seem to be a way to close a panel by name.
     view.window().run_command('hide_panel', {'panel': 'output.' + ERROR_PANEL_NAME})
 
 def parse_error_messages(base_dir, text):

--- a/autobuild.py
+++ b/autobuild.py
@@ -56,7 +56,9 @@ class SublimeHaskellAutobuild(sublime_plugin.EventListener):
     def on_selection_modified(self, view):
         cabal_project_dir = get_cabal_project_dir_of_view(view)
 
-        if cabal_project_dir is not None:
+        this_view_has_a_warning = view.id() in WARNINGS
+
+        if cabal_project_dir is not None and this_view_has_a_warning:
             lineno = last_selected_lineno(view)
             if lineno != self.last_selected_lineno:
                 self.last_selected_lineno = lineno

--- a/autobuild.py
+++ b/autobuild.py
@@ -64,7 +64,7 @@ class SublimeHaskellAutobuild(sublime_plugin.EventListener):
                 vid = view.id()
 
                 # Only deal with warnings if there are no errors
-                if not ERRORS[vid]:
+                if not ERRORS.get(vid):
                     hide_output(view)
                     warning = WARNINGS.get(vid, {}).get(lineno)
                     if warning:


### PR DESCRIPTION
Originally, we showed all warnings and errors in the error panel.

That was a bit obtrusive, so since a3f63634, only errors are shown there.

With this commit, warning details are shown when the cursor is in the corresponding line.
