### PR TITLE
Fix broken ghc-mod execution

### DIFF
--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -331,7 +331,7 @@ def get_source_dir(filename):
     if not cabal_dir:
         return os.path.dirname(filename)
 
-    cabal_file = get_cabal_in_dir(cabal_dir)[1]
+    _project_name, cabal_file = get_cabal_in_dir(cabal_dir)
     exit_code, out, err = call_and_wait([CABAL_INSPECTOR_EXE_PATH, cabal_file])
 
     if exit_code == 0:


### PR DESCRIPTION
cwd parameter to ghc-mod was broken.

All call to ghc-mod using call_ghcmod_and_wait broken without this fix.
