### PR TITLE
Snippets for unicode syntax

### DIFF
--- a/Snippets/Unicode Syntax/←.sublime-snippet
+++ b/Snippets/Unicode Syntax/←.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-← 
+←
 ]]></content>
   <tabTrigger>&lt;-</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/→.sublime-snippet
+++ b/Snippets/Unicode Syntax/→.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-→ 
+→
 ]]></content>
   <tabTrigger>-&gt;</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/↢.sublime-snippet
+++ b/Snippets/Unicode Syntax/↢.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-↢ 
+↢
 ]]></content>
   <tabTrigger>-&lt;</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/↣.sublime-snippet
+++ b/Snippets/Unicode Syntax/↣.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-↣ 
+↣
 ]]></content>
   <tabTrigger>&gt;-</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/⇒.sublime-snippet
+++ b/Snippets/Unicode Syntax/⇒.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-⇒ 
+⇒
 ]]></content>
   <tabTrigger>=&gt;</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/∀.sublime-snippet
+++ b/Snippets/Unicode Syntax/∀.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-∀ 
+∀
 ]]></content>
   <tabTrigger>forall</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/∷.sublime-snippet
+++ b/Snippets/Unicode Syntax/∷.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-∷ 
+∷
 ]]></content>
   <tabTrigger>::</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/★.sublime-snippet
+++ b/Snippets/Unicode Syntax/★.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-★ 
+★
 ]]></content>
   <tabTrigger>*</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/⤛.sublime-snippet
+++ b/Snippets/Unicode Syntax/⤛.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-⤛ 
+⤛
 ]]></content>
   <tabTrigger>-&lt;&lt;</tabTrigger>
   <scope>source.haskell</scope>

--- a/Snippets/Unicode Syntax/⤜.sublime-snippet
+++ b/Snippets/Unicode Syntax/⤜.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-⤜ 
+⤜
 ]]></content>
   <tabTrigger>&gt;&gt;-</tabTrigger>
   <scope>source.haskell</scope>


### PR DESCRIPTION
This allows to comfortly type in haskell unicode syntax, e.g., typing

```
"-" + ">" + TAB
```

will result in 

```
"→ "
```

getting inserted. 

For more info on unicode syntax [see this](http://www.haskell.org/ghc/docs/latest/html/users_guide/syntax-extns.html#unicode-syntax)  and [this](http://www.haskell.org/haskellwiki/Unicode-symbols). 

It makes sense to extend this with support for [this library](http://hackage.haskell.org/package/base-unicode-symbols) in future.
