### PR TITLE
Fix broken autocomplete

### DIFF
--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -369,7 +369,7 @@ def get_source_dir(filename):
                 dirs.extend(info['library']['info']['source-dirs'])
             for i in info['executables']:
                 dirs.extend(i['info']['source-dirs'])
-            for t in info['tests']:
+            for i in info['tests']:
                 dirs.extend(i['info']['source-dirs'])
 
         paths = [os.path.abspath(os.path.join(cabal_dir, d)) for d in dirs]


### PR DESCRIPTION
SublimeHaskell fails to load properly when Sublime is started due to a typo.

It fails with this exception;

```
Sublime Haskell: reinspecting project (/Users/kolmodin/code/binary-bits)
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/threading.py", line 532, in __bootstrap_inner
    self.run()
  File "./autocomplete.py", line 943, in run
  File "./autocomplete.py", line 1004, in _refresh_all_module_info
  File "./autocomplete.py", line 1050, in _refresh_module_info
  File "./sublime_haskell_common.py", line 373, in get_source_dir
UnboundLocalError: local variable 'i' referenced before assignment
```
