### PR TITLE
Add .cabal file to build ModuleInspector and CabalInspector

### DIFF
--- a/SublimeHaskell.cabal
+++ b/SublimeHaskell.cabal
@@ -34,5 +34,5 @@ executable CabalInspector
   build-depends:
     aeson,
     base,
-    Cabal>=1.16,
+    Cabal,
     text

--- a/SublimeHaskell.cabal
+++ b/SublimeHaskell.cabal
@@ -1,0 +1,38 @@
+name:                SublimeHaskell
+version:             0.1
+synopsis:            Tools bundled with SublimeHaskell
+description:         
+license:             MIT
+license-file:        LICENSE.txt
+author:              SublimeHaskell Team
+maintainer:          SublimeHaskell Team
+category:            IDE Tools
+build-type:          Simple
+
+cabal-version: >= 1.10
+
+source-repository head
+  type: git
+  location: git://github.com/SublimeHaskell/SublimeHaskell.git
+
+executable ModuleInspector
+  main-is: ModuleInspector.hs
+  default-language: Haskell2010
+  build-depends:
+    aeson,
+    base,
+    containers,
+    directory,
+    ghc,
+    haddock,
+    haskell-src-exts,
+    text
+
+executable CabalInspector
+  main-is: CabalInspector.hs
+  default-language: Haskell2010
+  build-depends:
+    aeson,
+    base,
+    Cabal>=1.16,
+    text


### PR DESCRIPTION
A start to build the bundled tools with Cabal instead of building the binaries standalone.
Code to actually build the cabal file will need to be added as well.
Also conditional code for each haddock version.

This will solve and simplify debugging of a number of issues: #49, #32, #31
Related bug: #40