### PR TITLE
Fix syntactic support for class declarations without "where".

### DIFF
--- a/Haskell-SublimeHaskell.tmLanguage
+++ b/Haskell-SublimeHaskell.tmLanguage
@@ -99,7 +99,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\b(where)\b</string>
+			<string>\b(where)\b|$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
E.g.:

```
class (Eq a, Show a) => A a
```
