### PR TITLE
Set cwd to `get_source_dir(filename)` when running ghc-mod.

### DIFF
--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -432,7 +432,7 @@ def call_ghcmod_and_wait(arg_list, filename=None, cabal = None):
         # Otherwise ghc-mod will fail with 'cannot satisfy package...'
         # Seems, that user directory works well
         # Current source directory is set with -i argument in get_ghc_opts_args
-        exit_code, out, err = call_and_wait(command, cwd=get_source_dir(None))
+        exit_code, out, err = call_and_wait(command, cwd=get_source_dir(filename))
 
         if exit_code != 0:
             raise Exception("ghc-mod exited with status %d and stderr: %s" % (exit_code, err))


### PR DESCRIPTION
Fixes error that ghc-mod can't find a library in an executable in the following setup:

```
name: mypackage
library
  hs-source-dirs: src
executable
  hs-source-dirs: apps
```

@mvoidex Can you check if this breaks something for you?
