### PR TITLE
"import" syntax fix

### DIFF
--- a/Haskell-SublimeHaskell.tmLanguage
+++ b/Haskell-SublimeHaskell.tmLanguage
@@ -165,7 +165,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(import)</string>
+			<string>\b(import)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Turns this 
![image](https://f.cloud.github.com/assets/1560937/659344/0be38254-d689-11e2-9726-6a05ec359e8a.png)

into this

![image](https://f.cloud.github.com/assets/1560937/659345/24651504-d689-11e2-944d-f9d8d8fec6a2.png)
