### PR TITLE
A workaround for lonely function titles in type declaration

### DIFF
--- a/Haskell-SublimeHaskell.tmLanguage
+++ b/Haskell-SublimeHaskell.tmLanguage
@@ -397,6 +397,20 @@
 				</dict>
 			</array>
 		</dict>
+    <dict>
+      <key>comment</key>
+      <string>A workaround for lonely function titles in type declaration. We're exploiting the fact that they are the only possible single-word declarations on a zero-indent.</string>
+      <key>match</key>
+      <string>^([a-z_][a-zA-Z0-9_']*|\([|!%$+\-.,=&lt;/&gt;]+\))\s*$</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>entity.name.function.haskell</string>
+        </dict>
+      </dict>
+    </dict>
 		<dict>
 			<key>match</key>
 			<string>\b(Just|Nothing|Left|Right|True|False|LT|EQ|GT|\(\)|\[\])\b</string>


### PR DESCRIPTION
We're exploiting the fact that they are the only possible single-word declarations on a zero-indent.

![image](https://f.cloud.github.com/assets/1560937/664477/0ae0c63e-d786-11e2-89f2-653cf4e3edec.png)

![image](https://f.cloud.github.com/assets/1560937/664480/2a85fc8e-d786-11e2-9427-ffa60a5d6123.png)
