### PR TITLE
New setting 'cache_path' to override the default path for local caches and built tools

### DIFF
--- a/SublimeHaskell.sublime-settings
+++ b/SublimeHaskell.sublime-settings
@@ -89,5 +89,15 @@
 	// Needed for autocompletion.
 	// This can take a lot of time in really big Haskell projects.
 	// Changing this requires a Sublime restart.
-	"inspect_modules": true
+	"inspect_modules": true,
+
+	// Relative or absolute path to a folder where local caches are stored.
+	// The same folder is used to store the CabalInspector/ModuleInspector tools.
+	// This setting is useful for preventing auto-generated or inherently local
+	// files from being synchronized by Dropbox and the like.
+	// Changing this requires a Sublime restart.
+	// Examples:
+	// 		"cache_path": "../../Local/SublimeHaskell"
+	// 		"cache_path": "%TEMP%\\SublimeHaskell"
+	"cache_path": "."
 }

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -36,8 +36,6 @@ CABAL_INSPECTOR_SOURCE_PATH = None
 CABAL_INSPECTOR_EXE_PATH = None
 CABAL_INSPECTOR_OBJ_DIR = None
 
-OUTPUT_PATH = None
-
 # ModuleInspector output
 MODULE_INSPECTOR_RE = re.compile(r'ModuleInfo:(?P<result>.+)')
 
@@ -889,7 +887,6 @@ class InspectorAgent(threading.Thread):
 
     def run(self):
         # Compile the CabalInspector:
-        # TODO: Where to compile it?
         with status_message(InspectorAgent.CABALMSG) as s:
 
             exit_code, out, err = call_and_wait(['ghc',
@@ -1276,17 +1273,16 @@ def plugin_loaded():
     global CABAL_INSPECTOR_SOURCE_PATH
     global CABAL_INSPECTOR_EXE_PATH
     global CABAL_INSPECTOR_OBJ_DIR
-    global OUTPUT_PATH
 
     package_path = sublime_haskell_package_path()
+    cache_path = sublime_haskell_cache_path()
 
     MODULE_INSPECTOR_SOURCE_PATH = os.path.join(package_path, 'ModuleInspector.hs')
-    MODULE_INSPECTOR_EXE_PATH = os.path.join(package_path, 'ModuleInspector')
-    MODULE_INSPECTOR_OBJ_DIR = os.path.join(package_path, 'obj/ModuleInspector')
+    MODULE_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'ModuleInspector')
+    MODULE_INSPECTOR_OBJ_DIR = os.path.join(cache_path, 'obj/ModuleInspector')
     CABAL_INSPECTOR_SOURCE_PATH = os.path.join(package_path, 'CabalInspector.hs')
-    CABAL_INSPECTOR_EXE_PATH = os.path.join(package_path, 'CabalInspector')
-    CABAL_INSPECTOR_OBJ_DIR = os.path.join(package_path, 'obj/CabalInspector')
-    OUTPUT_PATH = os.path.join(package_path, 'module_info.cache')
+    CABAL_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'CabalInspector')
+    CABAL_INSPECTOR_OBJ_DIR = os.path.join(cache_path, 'obj/CabalInspector')
 
     if get_setting('inspect_modules'):
         global std_inspector

--- a/cache.py
+++ b/cache.py
@@ -131,8 +131,9 @@ def plugin_loaded():
     global PROJECTS_CACHE_PATH
 
     package_path = sublime_haskell_package_path()
+    cache_path = sublime_haskell_cache_path()
 
-    CACHE_PATH = os.path.join(package_path, 'cache')
+    CACHE_PATH = os.path.join(cache_path, 'cache')
     CABAL_CACHE_PATH = os.path.join(CACHE_PATH, 'cabal')
     PROJECTS_CACHE_PATH = os.path.join(CACHE_PATH, 'projects')
 

--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -13,9 +13,6 @@ import time
 # This dirty hack is used in wait_for_window function
 MAX_WAIT_FOR_WINDOW = 10
 
-# The path to where this package is installed:
-PACKAGE_PATH = None
-
 # Panel for SublimeHaskell errors
 SUBLIME_ERROR_PANEL_NAME = 'haskell_sublime_load'
 
@@ -655,14 +652,24 @@ def status_message_process(msg, isok = True, timeout = 300, priority = 0):
     return with_status_message(msg, isok, lambda m, ok = None: show_status_message_process(m, ok, timeout, priority))
 
 def sublime_haskell_package_path():
+    """Get the path to where this package is installed"""
     return os.path.dirname(os.path.realpath(__file__))
 
+def sublime_haskell_cache_path():
+    """Get the path where compiled tools and caches are stored"""
+    return os.path.join(sublime_haskell_package_path(), os.path.expandvars(get_setting('cache_path', '.')))
 
 def plugin_loaded():
-    global PACKAGE_PATH
     global CABAL_INSPECTOR_EXE_PATH
-    PACKAGE_PATH = sublime_haskell_package_path()
-    CABAL_INSPECTOR_EXE_PATH = os.path.join(PACKAGE_PATH, 'CabalInspector')
+
+    package_path = sublime_haskell_package_path()
+    cache_path = sublime_haskell_cache_path()
+
+    log("store compiled tools and caches to {0}".format(cache_path))
+    if not os.path.exists(cache_path):
+        os.makedirs(cache_path)
+
+    CABAL_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'CabalInspector')
     preload_settings()
     
 if int(sublime.version()) < 3000:


### PR DESCRIPTION
New setting 'cache_path' to override the default path used for the CabalInspector/ModuleInspector tools and local caches. The value can be a relative or absolute path (environment variables will be expanded appropriately).

This setting is useful for preventing auto-generated or inherently local files from being synchronized by Dropbox and the like.
