### PR TITLE
Don't attempt to check & lint Cabal files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation
 
 Usage
 -----
-In short: Press `Shift-Ctrl-P` and type `haskell` to explore all commends.
+In short: Press `Shift-Ctrl-P` and type `haskell` to explore all commands.
 
 When editing Haskell source files that are part of a Cabal project, automatic error highlighting and enhanced auto-completion are available.
 

--- a/ghcmod.py
+++ b/ghcmod.py
@@ -5,12 +5,12 @@ import sublime_plugin
 from threading import Thread
 
 if int(sublime.version()) < 3000:
-    from sublime_haskell_common import log, is_enabled_haskell_command, get_haskell_command_window_view_file_project, call_ghcmod_and_wait, get_setting_async
+    from sublime_haskell_common import log, is_haskell_source, get_haskell_command_window_view_file_project, call_ghcmod_and_wait, get_setting_async
     from parseoutput import parse_output_messages, show_output_result_text, format_output_messages, mark_messages_in_views, hide_output, set_global_error_messages
     from ghci import parse_info
     import symbols
 else:
-    from SublimeHaskell.sublime_haskell_common import log, is_enabled_haskell_command, get_haskell_command_window_view_file_project, call_ghcmod_and_wait, get_setting_async
+    from SublimeHaskell.sublime_haskell_common import log, is_haskell_source, get_haskell_command_window_view_file_project, call_ghcmod_and_wait, get_setting_async
     from SublimeHaskell.parseoutput import parse_output_messages, show_output_result_text, format_output_messages, mark_messages_in_views, hide_output, set_global_error_messages
     from SublimeHaskell.ghci import parse_info
     import SublimeHaskell.symbols as symbols
@@ -27,7 +27,7 @@ class SublimeHaskellGhcModCheck(sublime_plugin.WindowCommand):
         run_ghcmod(['check'], 'Checking')
 
     def is_enabled(self):
-        return is_enabled_haskell_command(None, False)
+        return is_haskell_source(None)
 
 
 class SublimeHaskellGhcModLint(sublime_plugin.WindowCommand):
@@ -35,7 +35,7 @@ class SublimeHaskellGhcModLint(sublime_plugin.WindowCommand):
         run_ghcmod(['lint', '-h', '-u'], 'Linting', lint_as_hints)
 
     def is_enabled(self):
-        return is_enabled_haskell_command(None, False)
+        return is_haskell_source(None)
 
 
 class SublimeHaskellGhcModCheckAndLint(sublime_plugin.WindowCommand):
@@ -43,7 +43,7 @@ class SublimeHaskellGhcModCheckAndLint(sublime_plugin.WindowCommand):
         run_ghcmods([['check'], ['lint', '-h', '-u']], 'Checking and Linting', lint_as_hints)
 
     def is_enabled(self):
-        return is_enabled_haskell_command(None, False)
+        return is_haskell_source(None)
 
 
 def run_ghcmods(cmds, msg, alter_messages_cb=None):

--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -614,7 +614,16 @@ def show_status_message_process(msg, isok = None, timeout = 300, priority = 0):
         StatusMessage.messages[msg].start()
 
 def is_haskell_source(view = None):
-    return is_enabled_haskell_command(view, False)
+    window, view, file_shown_in_view = get_haskell_command_window_view_file_project(view)
+
+    if not window or not view:
+        return False
+
+    syntax_file_for_view = view.settings().get('syntax').lower()
+    if not syntax_file_for_view.endswith("Haskell.tmLanguage".lower()):
+        return False
+
+    return True
 
 class with_status_message(object):
     def __init__(self, msg, isok, show_message):


### PR DESCRIPTION
Use fixed is_haskell_source() to determine if the current view is worth checking & linting as Haskell source.
