### PR TITLE
Fixes for syntax highlighting

### DIFF
--- a/Cabal.tmLanguage
+++ b/Cabal.tmLanguage
@@ -46,7 +46,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(?i)(executable|library|test-suite)\s+(\w+)\s*$</string>
+			<string>^(?i)(executable|library|test-suite|benchmark|flag|source-repository)\s+([^\s,]+)\s*$</string>
 			<key>name</key>
 			<string>entity.cabal</string>
 		</dict>

--- a/Haskell-SublimeHaskell.tmLanguage
+++ b/Haskell-SublimeHaskell.tmLanguage
@@ -405,7 +405,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b[A-Z]\w*\b</string>
+			<string>\b[A-Z][A-Za-z_'0-9]*</string>
 			<key>name</key>
 			<string>constant.other.haskell</string>
 		</dict>


### PR DESCRIPTION
Haskell: Allow single quotes for constructor identifiers
Cabal: Highlight all supported sections and match section values properly
