### PR TITLE
mixed tabs/spaces error

### DIFF
--- a/autocomplete.py
+++ b/autocomplete.py
@@ -987,8 +987,8 @@ class InspectorAgent(threading.Thread):
 
     def mark_file_dirty(self, filename):
         "Report that a file should be reinspected."
-	if filename is None:
-	    return
+        if filename is None:
+            return
         with self.dirty_files_lock:
             self.dirty_files.append(filename)
         self.reinspect_event.set()


### PR DESCRIPTION
fixes a tabs/spaces error when sublime loads autocomplete.py
