### PR TITLE
Add Comments.tmPreferences to disable indentation on comments; this screws up the compiler sometimes.

### DIFF
--- a/Syntaxes/Comments.tmPreferences
+++ b/Syntaxes/Comments.tmPreferences
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.haskell</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>{-</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>-}</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>--</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_DISABLE_INDENT_2</string>
+				<key>value</key>
+				<string>yes</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_DISABLE_INDENT</string>
+				<key>value</key>
+				<string>yes</string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>E3994307-4D9E-44D6-832E-52C244F1CDF3</string>
+</dict>
+</plist>


### PR DESCRIPTION
... indented commented line in Haskell will sometimes screw up the compiler. For example:

foo :: Int -> Int -> String
foo x y
    | x < y = "Less Than"
    --| x == y = "Equal"
    | x > y = "Greater Than"

main = do
    putStrLn (foo 1 2)

This code will fail to compile with an error: "src/Main.hs:4:20: parse error on input `='"

Move the comment to the beginning of the line like so:

foo :: Int -> Int -> String
foo x y
    | x < y = "Less Than"
--  | x == y = "Equal"
    | x > y = "Greater Than"

main = do
    putStrLn (foo 1 2)

And everything compiles just fine.
