### PR TITLE
`Toggle symbol info at status bar` command

### DIFF
--- a/Commands/Default.sublime-commands
+++ b/Commands/Default.sublime-commands
@@ -26,6 +26,10 @@
         "command": "sublime_haskell_symbol_info"
     },
     {
+        "caption": "SublimeHaskell: Toggle symbol info at status bar",
+        "command": "sublime_haskell_toggle_symbol_info_status_bar"
+    },
+    {
         "caption": "SublimeHaskell: Browse module",
         "command": "sublime_haskell_browse_module"
     },

--- a/Settings/SublimeHaskell.sublime-settings
+++ b/Settings/SublimeHaskell.sublime-settings
@@ -91,6 +91,9 @@
 	// Changing this requires a Sublime restart.
 	"inspect_modules": true,
 
+	// Show symbol info at the status bar instead of in its own panel.
+	"enable_symbol_info_at_status_bar": false,
+
 	// Relative or absolute path to a folder where local caches are stored.
 	// The same folder is used to store the CabalInspector/ModuleInspector tools.
 	// This setting is useful for preventing auto-generated or inherently local

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -393,7 +393,13 @@ class SublimeHaskellReinspectAll(sublime_plugin.WindowCommand):
 
 
 
-class SublimeHaskellSymbolInfoCommand(sublime_plugin.TextCommand):
+class SublimeHaskellToggleSymbolInfoStatusBarCommand(sublime_plugin.TextCommand):
+    """Toggles showing symbol type info at status bar instead of panel."""
+    toggle_setting_async('enable_symbol_info_at_status_bar')
+
+
+
+class SublimeHaskellSymbolInfoCommand(sublime_plugin.TextCommand, output_area):
     """
     Show information about selected symbol
 
@@ -537,20 +543,23 @@ class SublimeHaskellSymbolInfoCommand(sublime_plugin.TextCommand):
             show_status_message("Can't get info for {0}.{1}".format(module_name, ident_name), False)
 
     def show_symbol_info(self, decl):
-        output_view = self.view.window().get_output_panel('sublime_haskell_symbol_info')
-        output_view.set_read_only(False)
-
         util.refine_decl(decl)
 
-        # TODO: Move to separate command for Sublime Text 3
-        output_view.run_command('sublime_haskell_output_text', {
-            'text': decl.detailed() })
+        if get_setting_async('enable_symbol_info_at_status_bar'):
+            show_status_message(decl.detailed().split('\n')[0])
+        else:
+            output_view = self.view.window().get_output_panel('sublime_haskell_symbol_info')
+            output_view.set_read_only(False)
 
-        output_view.sel().clear()
-        output_view.set_read_only(True)
+            # TODO: Move to separate command for Sublime Text 3
+            output_view.run_command('sublime_haskell_output_text', {
+                'text': decl.detailed()})
 
-        self.view.window().run_command('show_panel', {
-            'panel': 'output.' + 'sublime_haskell_symbol_info' })
+            output_view.sel().clear()
+            output_view.set_read_only(True)
+
+            self.view.window().run_command('show_panel', {
+                'panel': 'output.' + 'sublime_haskell_symbol_info' })
 
     def browse_module(self, module):
         with autocompletion.database.modules as modules:

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -399,7 +399,7 @@ class SublimeHaskellToggleSymbolInfoStatusBarCommand(sublime_plugin.TextCommand)
 
 
 
-class SublimeHaskellSymbolInfoCommand(sublime_plugin.TextCommand, output_area):
+class SublimeHaskellSymbolInfoCommand(sublime_plugin.TextCommand):
     """
     Show information about selected symbol
 

--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -247,7 +247,6 @@ def find_file_in_parent_dir(subdirectory, filename_pattern):
         if last_dir == current_dir:
             return None
 
-
 def are_paths_equal(path, other_path):
     "Test whether filesystem paths are equal."
     path = os.path.abspath(path)
@@ -359,6 +358,31 @@ def set_setting(key, value):
 
 def set_setting_async(key, value):
     sublime.set_timeout(lambda: set_setting(key, value), 0)
+
+def _toggle_setting(key, is_asynchronous = True):
+    """
+    'Flips' a Boolean setting.
+    WARNING: Does no typechecking for Boolean input before being applied.
+    """
+    function = None
+
+    if is_asynchronous:
+        function = set_setting_async
+    else
+        function = set_setting
+
+    with sublime_haskell_settings as settings:
+        if settings[key]:
+            function(key, False)
+        else
+            function(key, True)
+
+def toggle_setting(key):
+    _toggle_setting(key, is_asynchronous = True)
+
+def toggle_setting_async(key):
+    _toggle_setting(key, is_asynchronous = False)
+
 
 def ghci_package_db(cabal = None):
     if cabal == 'cabal':


### PR DESCRIPTION
This is an alternative way of implementing a suggestion I gave at #134.

It adds a `Toggle symbol info at status bar` command that 
redirects `Show info` between the current panel and the status bar.
 
If a `sublime_plugin.EventListener` to call `sublime_haskell_symbol_info_command` periodically updates the status bar, this becomes a faster way to read types while browsing a file.
I plan on at least adding another commit where this happens by calling it after a delay where no move events fired.

Can anyone review this?
In particular, this down at autocomplete.py looks funky at the moment:
```python
show_status_message(decl.detailed().split('\n')[0])
```

(I understand this is not a TODO within the project, but maybe it's a valuable feature to you.
I miss this functionality from Emacs and didn't find a command within that did it)