### PR TITLE
Support * as an operator

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.tmLanguage
+++ b/Syntaxes/Haskell-SublimeHaskell.tmLanguage
@@ -427,7 +427,7 @@
 			<key>comment</key>
 			<string>In case this regex seems overly general, note that Haskell permits the definition of new operators which can be nearly any string of punctuation characters, such as $%^&amp;*.</string>
 			<key>match</key>
-			<string>[|!%$?~+:\-.=&lt;/&gt;\\]+</string>
+			<string>[|!%$?~+:\-.*=&lt;/&gt;\\]+</string>
 			<key>name</key>
 			<string>keyword.operator.haskell</string>
 		</dict>
@@ -493,7 +493,7 @@
 		<key>infix_op</key>
 		<dict>
 			<key>match</key>
-			<string>(\([|!%$+:\-.=&lt;/&gt;]+\)|\(,+\))</string>
+			<string>(\([|!%$+:\-.*=&lt;/&gt;]+\)|\(,+\))</string>
 			<key>name</key>
 			<string>entity.name.function.infix.haskell</string>
 		</dict>


### PR DESCRIPTION
Added \* to the patterns for keyword.operator.haskell and entity.name.function.infix.haskell so that operators like `*`, `:*:`, and `<*>` get highlighted properly.
