### PR TITLE
Builds CabalInspector and ModuleInspector with cabal-install using a sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ Requirements
 ------------
 
 Necessary:
-* ghc and a recent Haskell Platform (>= 2012 should do fine)
-* cabal
-* Cabal packages: base, bytestring, aeson, haskell-src-exts (== 1.14.*), haddock (`cabal install aeson haskell-src-exts haddock`)
-* If you are using GHC 7.6, you might have trouble with too new versions of haddock; in that case, try `cabal install haddock --constraint=haddock==2.13.2.1`
+* A relatively recent ghc (7.4 or later)
+* cabal 1.18 or later
 
 Optional, but useful:
 * [ghc-mod](http://hackage.haskell.org/package/ghc-mod) (for import and LANGUAGE completions and type inference, `cabal install ghc-mod`)

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/SublimeHaskell.cabal
+++ b/SublimeHaskell.cabal
@@ -20,7 +20,7 @@ executable ModuleInspector
   other-extensions:    OverloadedStrings
   build-depends:       base
                       ,ghc
-                      ,haddock
+                      ,haddock-api
                       ,text >=1.0
                       ,containers >=0.4
                       ,directory >=1.0

--- a/SublimeHaskell.cabal
+++ b/SublimeHaskell.cabal
@@ -1,0 +1,41 @@
+name:                SublimeHaskell
+version:             0.1.0.0
+synopsis:            SublimeHaskell's tools            
+homepage:            https://github.com/SublimeHaskell/SublimeHaskell
+
+license:             MIT
+license-file:        LICENSE.txt
+author:              Keith Holman
+-- maintainer:        
+-- copyright:           
+
+category:            Development
+build-type:          Simple
+
+cabal-version:       >=1.10
+
+executable ModuleInspector
+  main-is:             ModuleInspector.hs
+
+  other-extensions:    OverloadedStrings
+  build-depends:       base
+                      ,ghc
+                      ,haddock
+                      ,text >=1.0
+                      ,containers >=0.4
+                      ,directory >=1.0
+                      ,aeson >= 0.7
+                      ,haskell-src-exts == 1.14.*
+
+  default-language:    Haskell2010
+
+
+executable CabalInspector
+  main-is:             CabalInspector.hs
+
+  build-depends:       base
+                      ,Cabal >=1.14
+                      ,text >=1.0
+                      ,aeson >= 0.7
+
+  default-language:    Haskell2010

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -930,10 +930,7 @@ class InspectorAgent(threading.Thread):
                 '--force-reinstalls', # safely overrides packages in the global db
                 '--disable-library-profiling',
                 '--disable-shared',
-                '--disable-library-for-ghci',
                 '--disable-tests',
-                '--disable-library-coverage',
-                '--disable-benchmarks',
                 '--disable-documentation'],
                 cwd = TOOLS_CABAL_FILE_DIR)
 

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -29,12 +29,11 @@ else:
 # If true, files that have not changed will not be re-inspected.
 CHECK_MTIME = True
 
-MODULE_INSPECTOR_SOURCE_PATH = None
+TOOLS_CABAL_FILE_DIR = None
+TOOLS_BUILD_DIR = None
+TOOLS_SANDBOX_DIR = None
 MODULE_INSPECTOR_EXE_PATH = None
-MODULE_INSPECTOR_OBJ_DIR = None
-CABAL_INSPECTOR_SOURCE_PATH = None
 CABAL_INSPECTOR_EXE_PATH = None
-CABAL_INSPECTOR_OBJ_DIR = None
 INSPECTOR_ENABLED = False
 INSPECTOR_RUNNING = False
 
@@ -905,36 +904,57 @@ class InspectorAgent(threading.Thread):
         # Event that is set (notified) when files have changed
         self.reinspect_event = threading.Event()
 
-    CABALMSG = 'Compiling Haskell CabalInspector'
-    MODULEMSG = 'Compiling Haskell ModuleInspector'
+    SANDBOXMSG = 'Initializing Haskell tools sandbox'
+    DEPSMSG = 'Compiling Haskell tools dependencies. This can take several minutes, be patient!'
+    TOOLSMSG = 'Compiling Haskell tools'
 
     def run(self):
-        # Compile the CabalInspector:
-        with status_message(InspectorAgent.CABALMSG) as s:
-
-            exit_code, out, err = call_and_wait(['ghc',
-                '--make', CABAL_INSPECTOR_SOURCE_PATH,
-                '-o', CABAL_INSPECTOR_EXE_PATH,
-                '-outputdir', CABAL_INSPECTOR_OBJ_DIR])
+        # Make sure there is a sandbox here
+        with status_message(InspectorAgent.SANDBOXMSG) as s:
+            exit_code, out, err = call_and_wait(['cabal',
+               'sandbox', 'init',
+               '--sandbox='+TOOLS_SANDBOX_DIR],
+                cwd = TOOLS_CABAL_FILE_DIR)
 
             if exit_code != 0:
                 s.fail()
-                error_msg = u"SublimeHaskell: Failed to compile CabalInspector\n{0}".format(err)
+                error_msg = u"SublimeHaskell: Failed to initialize a Cabal sandbox\n{0}".format(err)
                 wait_for_window(lambda w: self.show_errors(w, error_msg))
-                # Continue anyway
+                return
 
-        # Compile the ModuleInspector:
-        with status_message(InspectorAgent.MODULEMSG) as s:
-
-            exit_code, out, err = call_and_wait(['ghc',
-                '--make', MODULE_INSPECTOR_SOURCE_PATH,
-                '-package', 'ghc',
-                '-o', MODULE_INSPECTOR_EXE_PATH,
-                '-outputdir', MODULE_INSPECTOR_OBJ_DIR])
+        # Install all the dependencies, if necessary
+        with status_message(InspectorAgent.DEPSMSG) as s:
+            exit_code, out, err = call_and_wait(['cabal',
+                'install',
+                '--only-dependencies',
+                '--force-reinstalls', # safely overrides packages in the global db
+                '--disable-library-profiling',
+                '--disable-shared',
+                '--disable-library-for-ghci',
+                '--disable-tests',
+                '--disable-library-coverage',
+                '--disable-benchmarks',
+                '--disable-documentation'],
+                cwd = TOOLS_CABAL_FILE_DIR)
 
             if exit_code != 0:
                 s.fail()
-                error_msg = u"SublimeHaskell: Failed to compile ModuleInspector\n{0}".format(err)
+                error_msg = u"SublimeHaskell: Failed to install tool dependencies\n{0}".format(err)
+                wait_for_window(lambda w: self.show_errors(w, error_msg))
+                return
+
+
+        # Compile the tools
+        with status_message(InspectorAgent.TOOLSMSG) as s:
+
+            exit_code, out, err = call_and_wait(['cabal',
+                'build',
+                '--builddir='+TOOLS_BUILD_DIR],
+                cwd = TOOLS_CABAL_FILE_DIR)
+
+            if exit_code != 0:
+                s.fail()
+                error_msg = u"SublimeHaskell: Failed to compile tools\n{0}".format(err)
                 wait_for_window(lambda w: self.show_errors(w, error_msg))
                 return
 
@@ -1304,24 +1324,22 @@ def start_inspector():
 
 
 def plugin_loaded():
-    global MODULE_INSPECTOR_SOURCE_PATH
+    global TOOLS_CABAL_FILE_DIR
+    global TOOLS_BUILD_DIR
+    global TOOLS_SANDBOX_DIR
     global MODULE_INSPECTOR_EXE_PATH
-    global MODULE_INSPECTOR_OBJ_DIR
-    global CABAL_INSPECTOR_SOURCE_PATH
     global CABAL_INSPECTOR_EXE_PATH
-    global CABAL_INSPECTOR_OBJ_DIR
     global INSPECTOR_ENABLED
     global INSPECTOR_RUNNING
 
     package_path = sublime_haskell_package_path()
     cache_path = sublime_haskell_cache_path()
 
-    MODULE_INSPECTOR_SOURCE_PATH = os.path.join(package_path, 'ModuleInspector.hs')
-    MODULE_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'ModuleInspector')
-    MODULE_INSPECTOR_OBJ_DIR = os.path.join(cache_path, 'obj/ModuleInspector')
-    CABAL_INSPECTOR_SOURCE_PATH = os.path.join(package_path, 'CabalInspector.hs')
-    CABAL_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'CabalInspector')
-    CABAL_INSPECTOR_OBJ_DIR = os.path.join(cache_path, 'obj/CabalInspector')
+    TOOLS_CABAL_FILE_DIR  = package_path
+    TOOLS_BUILD_DIR = os.path.join(cache_path, 'tools/dist')
+    TOOLS_SANDBOX_DIR = os.path.join(cache_path, 'tools/cabal-sandbox')
+    MODULE_INSPECTOR_EXE_PATH = os.path.join(TOOLS_BUILD_DIR, 'build/ModuleInspector/ModuleInspector')
+    CABAL_INSPECTOR_EXE_PATH = os.path.join(TOOLS_BUILD_DIR, 'build/CabalInspector/CabalInspector')
     INSPECTOR_ENABLED = get_setting('inspect_modules')
 
     if INSPECTOR_ENABLED:

--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -725,7 +725,7 @@ def plugin_loaded():
     if not os.path.exists(cache_path):
         os.makedirs(cache_path)
 
-    CABAL_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'CabalInspector')
+    CABAL_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'tools/dist/build/CabalInspector/CabalInspector')
     preload_settings()
 
 if int(sublime.version()) < 3000:


### PR DESCRIPTION
`cabal-install` is used to build `CabalInspector` and `ModuleInspector` (instead of calling `ghc --make`). Moreover, all dependencies are automatically downloaded and installed on a sandbox. This means that the user no longer needs to install `aeson`, `haskell-src-exts` and `haddock` on the user-db (which proves to be problematic in practice), and that the plugin will break less often if ghc is updated (and eventual breakage should be more easily solved by picking the right dependencies in the new .cabal file provided).

This patch subsumes #59 and would close #153. 