### PR TITLE
Use cabal project directory to run ghc-mod when possible

### DIFF
--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -466,7 +466,15 @@ def call_ghcmod_and_wait(arg_list, filename=None, cabal = None):
         # Otherwise ghc-mod will fail with 'cannot satisfy package...'
         # Seems, that user directory works well
         # Current source directory is set with -i argument in get_ghc_opts_args
-        exit_code, out, err = call_and_wait(command, cwd=get_source_dir(filename))
+        #
+        # When cabal project is available current directory is set to the project root
+        # to avoid troubles with possible template haskell openFile calls
+        ghc_mod_current_dir = get_source_dir(filename)
+        if filename:
+            cabal_project_dir = get_cabal_project_dir_of_file(filename)
+            if cabal_project_dir:
+                ghc_mod_current_dir = cabal_project_dir
+        exit_code, out, err = call_and_wait(command, cwd=ghc_mod_current_dir)
 
         if exit_code != 0:
             raise Exception("%s exited with status %d and stderr: %s" % (' '.join(command), exit_code, err))


### PR DESCRIPTION
I'm doing lots of development with Yesod on Windows, so I had an issue with Sublime Haskell. The problem was that whenever I imported an external template file to my module like this:

```
 $(whamletFile "templates/content-configuration-form.hamlet")
```

I had the following error when running ghc-mod lint:

```
Exception when trying to run compile-time code:
  static: getDirectoryContents: does not exist (The system cannot find the path specified.)
Code: staticFiles staticDir
```

The reason of an error is that while cabal runs ghc binary right in the directory where .cabal file is located, SublimeHaskell attempts to run ghc-mod in the directory with the source file. That's why relative paths that are valid when building with cabal aren't valid anymore when running ghc-mod.

The proposed patch fixes that by using .cabal file directory when it's available
