### PR TITLE
Strip \r from output messages, if applicable

### DIFF
--- a/parseoutput.py
+++ b/parseoutput.py
@@ -47,7 +47,7 @@ class OutputMessage(object):
         self.filename = filename
         self.line = int(line)
         self.column = int(column)
-        self.message = message
+        self.message = message.replace(os.linesep, "\n")
         self.level = level
 
     def __unicode__(self):


### PR DESCRIPTION
On Windows, the error panel will display (CR) symbols at each newline,
so remove them if they're present.

![capture](https://cloud.githubusercontent.com/assets/3087971/4384318/aee09e94-43b4-11e4-8aba-3576a010d123.PNG)

This is on Sublime Text 3 (x64, build 3064), on Win8.1 x64.
