### PR TITLE
next/prev error: filename should be a string type

### DIFF
--- a/parseoutput.py
+++ b/parseoutput.py
@@ -230,7 +230,7 @@ class SublimeHaskellNextError(sublime_plugin.TextCommand):
     def run(self, edit):
         log("SublimeHaskellNextError")
         v = self.view
-        fn = v.file_name().encode("utf-8")
+        fn = v.file_name()
         line, column = v.rowcol(v.sel()[0].a)
         line += 1
         gotoline = -1
@@ -251,7 +251,7 @@ class SublimeHaskellNextError(sublime_plugin.TextCommand):
 class SublimeHaskellPreviousError(sublime_plugin.TextCommand):
     def run(self, edit):
         v = self.view
-        fn = v.file_name().encode("utf-8")
+        fn = v.file_name()
         line, column = v.rowcol(v.sel()[0].a)
         line += 1
         gotoline = -1


### PR DESCRIPTION
Fixes #171 

Removes encode("utf-8") calls to match as strings, rather than as a
bytes object against a string.

Caveat: I've only tested this on my system (Win8.1 x64, Sublime Text 3 (Build 3064)).
