### PR TITLE
added `happy` to dependencies to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Requirements
 Necessary:
 * ghc and a recent Haskell Platform (>= 2012 should do fine)
 * cabal
+* happy is indirect dependency for some of required packages. (`cabal install happy`)
 * Cabal packages: base, bytestring, aeson, haskell-src-exts (== 1.14.*), haddock (`cabal install aeson haskell-src-exts haddock`)
 * If you are using GHC 7.6, you might have trouble with too new versions of haddock; in that case, try `cabal install haddock --constraint=haddock==2.13.2.1`
 


### PR DESCRIPTION
happy is a preprocessing tool, so it is not required by cabal packages directly, so it will not be installed automatically and cabal would produce strange errors. It is best to install it prior to all other packages.
