### PR TITLE
Fixes for ST2 and Python 2.7 in Hsdev branch

### DIFF
--- a/autobuild.py
+++ b/autobuild.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import sublime
 import sublime_plugin
 

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -7,10 +7,15 @@ import re
 import sublime
 import sublime_plugin
 import threading
-import queue
 import time
 import sys
 import webbrowser
+
+try:
+    import queue
+except ImportError:
+    import Queue as queue
+
 
 if int(sublime.version()) < 3000:
     from sublime_haskell_common import *

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -1869,12 +1869,15 @@ class SublimeHaskellAutocomplete(sublime_plugin.EventListener):
 
         window = view.window()
         if window:
-            if not self.project_file_name:
-                self.project_file_name = window.project_file_name()
-            if window.project_file_name() is not None and window.project_file_name() != self.project_file_name:
-                self.project_file_name = window.project_file_name()
-                log('project switched to {0}, reinspecting'.format(self.project_file_name))
-                window.run_command('sublime_haskell_reinspect_all')
+            try:
+                if not self.project_file_name:
+                    self.project_file_name = window.project_file_name()
+                if window.project_file_name() is not None and window.project_file_name() != self.project_file_name:
+                    self.project_file_name = window.project_file_name()
+                    log('project switched to {0}, reinspecting'.format(self.project_file_name))
+                    window.run_command('sublime_haskell_reinspect_all')
+            except AttributeError:
+                pass
 
     def on_post_save(self, view):
         if is_inspected_source(view):

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import json
 import os
 import os.path

--- a/cabal.py
+++ b/cabal.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import sublime
 import sublime_plugin
 import sys

--- a/cabalbuild.py
+++ b/cabalbuild.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import os
 import os.path
 import sublime

--- a/cache.py
+++ b/cache.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import json
 import os
 import sublime

--- a/fix_syntax.py
+++ b/fix_syntax.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 # Sublime's built-in Haskell lexer (Packages/Haskell/Haskell.tmLanguage)
 # is slightly broken.
 #

--- a/ghci.py
+++ b/ghci.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import re
 import os
 import sublime

--- a/ghcmod.py
+++ b/ghcmod.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import os
 import re
 import sublime

--- a/haskell_docs.py
+++ b/haskell_docs.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import re
 import os
 import sublime

--- a/haskell_type.py
+++ b/haskell_type.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import sublime
 import sublime_plugin
 import re

--- a/hdevtools.py
+++ b/hdevtools.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import os
 import re
 import sublime

--- a/hdocs.py
+++ b/hdocs.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import sublime
 import json
 import time

--- a/hsdev.py
+++ b/hsdev.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import os
 import os.path
 import sys

--- a/hsdev.py
+++ b/hsdev.py
@@ -473,11 +473,11 @@ class HsDev(object):
 
     # Util
 
-    def check_version():
+    def check_version(self):
         (exit_code, out, err) = call_and_wait(['hsdev', 'version'])
         return exit_code == 0 and re.match(r'0\.1\.[1-9]\..', out) is not None
 
-    def start_server(port = 4567, cache = None):
+    def start_server(self, port = 4567, cache = None):
         cmd = concat_args([
             (True, ["hsdev", "start"]),
             (port, ["--port", str(port)]),

--- a/hsdev.py
+++ b/hsdev.py
@@ -423,7 +423,10 @@ def async_list_command(fn):
 def cmd(name_, args_ = [], opts_ = {}, on_result = lambda r: r):
     return (name_, args_, opts_, on_result)
 
-def call_callback(fn, *args, name = None, **kwargs):
+def call_callback(fn, *args, **kwargs):
+    name = kwargs.get('name')
+    if name:
+        del kwargs['name']
     try:
         if fn is not None:
             fn(*args, **kwargs)

--- a/parseoutput.py
+++ b/parseoutput.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import os
 import os.path
 import re

--- a/repl.py
+++ b/repl.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import sublime
 import sublime_plugin
 import re

--- a/stylishhaskell.py
+++ b/stylishhaskell.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import errno
 import sublime
 import sublime_plugin

--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import errno
 import fnmatch
 import os

--- a/symbols.py
+++ b/symbols.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import threading
 import sublime
 import os.path

--- a/util.py
+++ b/util.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import sublime
 
 if int(sublime.version()) < 3000:


### PR DESCRIPTION
Fixes for following and other errors:

Traceback (most recent call last):
  File "./sublime_plugin.py", line 175, in on_load
  File "./sublime_plugin.py", line 154, in run_timed_function
  File "./sublime_plugin.py", line 174, in <lambda>
  File "./autocomplete.py", line 1863, in on_load
  File "./autocomplete.py", line 1508, in wrapped
TypeError: acquire() takes no keyword arguments


Traceback (most recent call last):
  File "./sublime_plugin.py", line 362, in run_
  File "./autocomplete.py", line 868, in run
  File "./sublime_haskell_common.py", line 816, in show_status_message
TypeError: unbound method status() must be called with StatusMessage instance as first argument (got str instance instead)



Exception in thread Thread-5:
Traceback (most recent call last):
  File ".\threading.py", line 532, in __bootstrap_inner
  File "./autocomplete.py", line 1602, in run
  File "./autocomplete.py", line 1546, in start_hsdev
TypeError: unbound method check_version() must be called with HsDev instance as first argument (got nothing instead)



On rclick / Show symbol info:

Traceback (most recent call last):
  File "./sublime_plugin.py", line 362, in run_
  File "./autocomplete.py", line 868, in run
  File "./sublime_haskell_common.py", line 817, in show_status_message
TypeError: unbound method status() must be called with StatusMessage instance as first argument (got str instance instead)


