### PR TITLE
Patch-up for current versions of Cabal and haskell-src-exts

### DIFF
--- a/CabalInspector.hs
+++ b/CabalInspector.hs
@@ -74,7 +74,7 @@ analyzeCabal source = case parsePackageDescription source of
         cabalTests = fmap (toTest . second PD.condTreeData) $ PD.condTestSuites r }
     ParseFailed e -> Left $ "Parse failed: " ++ show e
     where
-        toLibrary (PD.Library exposeds _ info) = CabalLibrary (map components exposeds) (toInfo info)
+        toLibrary (PD.Library exposeds _ _ _ _ info) = CabalLibrary (map components exposeds) (toInfo info)
         toExecutable (name, PD.Executable _ path info) = CabalExecutable name path (toInfo info)
         toTest (name, PD.TestSuite _ _ info enabled) = CabalTest name enabled (toInfo info)
         toInfo info = Info {

--- a/ModuleInspector.hs
+++ b/ModuleInspector.hs
@@ -135,10 +135,9 @@ declInfo decl = case decl of
 defInfo :: H.Decl -> [DeclarationInfo]
 defInfo (H.FunBind []) = []
 defInfo (H.FunBind (H.Match loc n _ _ _ _ : _)) = [DeclarationInfo loc "function" (identOfName n) Nothing Nothing Nothing Nothing]
-defInfo (H.PatBind loc pat _ _ _) = map (\name -> DeclarationInfo loc "function" (identOfName name) Nothing Nothing Nothing Nothing) $ names pat where
+defInfo (H.PatBind loc pat _ _) = map (\name -> DeclarationInfo loc "function" (identOfName name) Nothing Nothing Nothing Nothing) $ names pat where
     names :: H.Pat -> [H.Name]
     names (H.PVar n) = [n]
-    names (H.PNeg n) = names n
     names (H.PNPlusK n _) = [n]
     names (H.PInfixApp l _ r) = names l ++ names r
     names (H.PApp _ ns) = concatMap names ns
@@ -156,7 +155,10 @@ defInfo (H.PatBind loc pat _ _ _) = map (\name -> DeclarationInfo loc "function"
 
     fieldNames :: H.PatField -> [H.Name]
     fieldNames (H.PFieldPat _ n) = names n
-    fieldNames (H.PFieldPun n) = [n]
+    fieldNames (H.PFieldPun n0) 
+      | H.Qual _ n <- n0 = [n]
+      | H.UnQual n <- n0 = [n]
+      | otherwise = [] -- Shouldn't ever happen in a pun.  Error instead?
     fieldNames H.PFieldWildcard = []
 defInfo _ = []
 


### PR DESCRIPTION
Here is the minimal change needed to get SublimeHaskell to work with current versions of Cabal and haskell-src-exts.

I am unsure on ignoring the module name in the qualified case (ModuleInspector.hs, line 158), but this is an edge case in the first place and is quite easy to change in future.