### PR TITLE
Fixes for ghc-mod invocation (#238, #241)

### DIFF
--- a/ghcmod.py
+++ b/ghcmod.py
@@ -191,26 +191,12 @@ def run_ghcmods(cmds, msg, alter_messages_cb=None):
         if alter_messages_cb:
             alter_messages_cb(msgs)
 
-        def compare(l, r):
-            # sort by file equality to file_name
-            res = cmp(l[1].filename != file_shown_in_view, r[1].filename != file_shown_in_view)
-            if res == 0:
-                # then by file
-                res = cmp(l[1].filename, r[1].filename)
-                if res == 0:
-                    # then by line
-                    res = cmp(l[1].line, r[1].line)
-                    if res == 0:
-                        # then by column
-                        res = cmp(l[1].column, r[1].column)
-            return res
-
         def sort_key(a):
             return (
                 a[1].filename != file_shown_in_view,
                 a[1].filename,
-                a[1].line,
-                a[1].column
+                a[1].start.line,
+                a[1].start.column
             )
 
         msgs.sort(key=sort_key)

--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -557,7 +557,7 @@ def call_ghcmod_and_wait(arg_list, filename=None, cabal = None):
     ghc_opts_args = get_ghc_opts_args(filename, add_package_db = False, cabal = cabal)
 
     try:
-        command = attach_cabal_sandbox(['ghc-mod'] + arg_list + ghc_opts_args, cabal)
+        command = attach_cabal_sandbox(['ghc-mod'] + ghc_opts_args + arg_list, cabal)
 
         # log('running ghc-mod: {0}'.format(command))
 


### PR DESCRIPTION
Replaces ghc-mod calls from this:
`ghc-mod lint -h PATH\FILE.hs -g -i PATH ` (causes errors shown in #241 #238)
to
`ghc-mod -g -i PATH lint -h PATH\FILE.hs`