### PR TITLE
Fix build errors in branch build-tools-with-sandbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+# See https://github.com/hvr/multi-ghc-travis for more information
+
+language: c
+
+sudo: false
+
+matrix:
+  include:
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+
+before_install:
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - travis_retry cabal update
+ - cabal sandbox init
+ - cabal install --only-dependencies
+
+script:
+ - cabal configure -v2
+ - cabal build
+
+notifications:
+  email:
+    - kolmodin@gmail.com

--- a/CabalInspector.hs
+++ b/CabalInspector.hs
@@ -74,7 +74,7 @@ analyzeCabal source = case parsePackageDescription source of
         cabalTests = fmap (toTest . second PD.condTreeData) $ PD.condTestSuites r }
     ParseFailed e -> Left $ "Parse failed: " ++ show e
     where
-        toLibrary (PD.Library exposeds _ info) = CabalLibrary (map components exposeds) (toInfo info)
+        toLibrary library = CabalLibrary (map components (PD.exposedModules library)) (toInfo (PD.libBuildInfo library))
         toExecutable (name, PD.Executable _ path info) = CabalExecutable name path (toInfo info)
         toTest (name, PD.TestSuite _ _ info enabled) = CabalTest name enabled (toInfo info)
         toInfo info = Info {

--- a/ModuleInspector.hs
+++ b/ModuleInspector.hs
@@ -18,11 +18,13 @@ import qualified System.Directory as Dir
 import System.IO
 
 import qualified Name (Name, getOccString, occNameString)
-import qualified Module (moduleNameString)
+import qualified OccName (OccName)
+import qualified Module (ModuleName, moduleNameString)
 import qualified SrcLoc as Loc
 import qualified HsDecls
 import qualified HsBinds
 import qualified Documentation.Haddock as Doc
+import qualified Documentation.Haddock.Types as DocT
 
 -- | All the information extracted from a codebase.
 data ModuleInfo = ModuleInfo
@@ -182,8 +184,10 @@ documentationMap iface = M.fromList $ concatMap toDoc $ Doc.ifaceExportItems ifa
         _ -> []
 
     extractDocs :: Doc.DocForDecl Name.Name -> Maybe String
-    extractDocs (mbDoc, _) = fmap printDoc $ Doc.documentationDoc mbDoc where
-        printDoc :: Doc.Doc Name.Name -> String
+    extractDocs (mbDoc, _) = fmap (printDoc . unDoc) $ Doc.documentationDoc mbDoc where
+        unDoc :: DocT.MetaDoc mod id -> Doc.DocH mod id
+        unDoc (DocT.MetaDoc meta doc) = doc
+        printDoc :: Doc.DocH (Module.ModuleName, OccName.OccName) Name.Name -> String
         printDoc Doc.DocEmpty = ""
         printDoc (Doc.DocAppend l r) = printDoc l ++ printDoc r
         printDoc (Doc.DocString s) = s

--- a/ModuleInspector.hs
+++ b/ModuleInspector.hs
@@ -176,7 +176,7 @@ documentationMap iface = M.fromList $ concatMap toDoc $ Doc.ifaceExportItems ifa
     extractNames (Loc.L _ d) = case d of
         HsDecls.TyClD ty -> [locatedName $ HsDecls.tcdLName ty]
         HsDecls.SigD sig -> case sig of
-            HsBinds.TypeSig names _ -> map locatedName names
+            HsBinds.TypeSig names _ _ -> map locatedName names
             HsBinds.GenericSig names _ -> map locatedName names
             _ -> []
         _ -> []

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Requirements
 ------------
 
 Necessary:
-* A relatively recent ghc (7.4 or later)
+* A recent ghc (7.10.x)
 * cabal 1.18 or later
 
 Optional, but useful:

--- a/SublimeHaskell.cabal
+++ b/SublimeHaskell.cabal
@@ -38,7 +38,7 @@ executable CabalInspector
   main-is:             CabalInspector.hs
 
   build-depends:       base
-                      ,Cabal >=1.14
+                      ,Cabal >=1.18
                       ,text >=1.0
                       ,aeson >= 0.7
 

--- a/SublimeHaskell.cabal
+++ b/SublimeHaskell.cabal
@@ -24,7 +24,7 @@ executable ModuleInspector
                       ,containers >=0.4
                       ,directory >=1.0
                       ,aeson >= 0.7
-                      ,haskell-src-exts == 1.14.*
+                      ,haskell-src-exts == 1.15.0.1
   if impl(ghc < 7.8.2)
     build-depends:     haddock < 2.15
   else

--- a/SublimeHaskell.cabal
+++ b/SublimeHaskell.cabal
@@ -28,7 +28,8 @@ executable ModuleInspector
   if impl(ghc < 7.8.2)
     build-depends:     haddock < 2.15
   else
-    build-depends:     haddock-api
+    build-depends:     haddock-api == 2.16.*
+                      ,haddock-library == 1.2.*
 
   default-language:    Haskell2010
 

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -30,7 +30,7 @@ else:
 CHECK_MTIME = True
 
 TOOLS_CABAL_FILE_DIR = None
-TOOLS_BUILD_DIR = None
+TOOLS_DIR = None
 TOOLS_SANDBOX_DIR = None
 MODULE_INSPECTOR_EXE_PATH = None
 CABAL_INSPECTOR_EXE_PATH = None
@@ -950,8 +950,8 @@ class InspectorAgent(threading.Thread):
         with status_message(InspectorAgent.TOOLSMSG) as s:
 
             exit_code, out, err = call_and_wait(['cabal',
-                'build',
-                '--builddir='+TOOLS_BUILD_DIR],
+                'install',
+                '--prefix='+TOOLS_DIR],
                 cwd = TOOLS_CABAL_FILE_DIR)
 
             if exit_code != 0:
@@ -1329,7 +1329,7 @@ def start_inspector():
 
 def plugin_loaded():
     global TOOLS_CABAL_FILE_DIR
-    global TOOLS_BUILD_DIR
+    global TOOLS_DIR
     global TOOLS_SANDBOX_DIR
     global MODULE_INSPECTOR_EXE_PATH
     global CABAL_INSPECTOR_EXE_PATH
@@ -1340,10 +1340,10 @@ def plugin_loaded():
     cache_path = sublime_haskell_cache_path()
 
     TOOLS_CABAL_FILE_DIR  = package_path
-    TOOLS_BUILD_DIR = os.path.join(cache_path, 'tools/dist')
-    TOOLS_SANDBOX_DIR = os.path.join(cache_path, 'tools/cabal-sandbox')
-    MODULE_INSPECTOR_EXE_PATH = os.path.join(TOOLS_BUILD_DIR, 'build/ModuleInspector/ModuleInspector')
-    CABAL_INSPECTOR_EXE_PATH = os.path.join(TOOLS_BUILD_DIR, 'build/CabalInspector/CabalInspector')
+    TOOLS_DIR = os.path.join(cache_path, 'tools')
+    TOOLS_SANDBOX_DIR = os.path.join(TOOLS_DIR, 'cabal-sandbox')
+    MODULE_INSPECTOR_EXE_PATH = os.path.join(TOOLS_DIR, 'bin/ModuleInspector')
+    CABAL_INSPECTOR_EXE_PATH = os.path.join(TOOLS_DIR, 'bin/CabalInspector')
     INSPECTOR_ENABLED = get_setting('inspect_modules')
 
     if INSPECTOR_ENABLED:

--- a/sublime_haskell_common.py
+++ b/sublime_haskell_common.py
@@ -725,7 +725,7 @@ def plugin_loaded():
     if not os.path.exists(cache_path):
         os.makedirs(cache_path)
 
-    CABAL_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'tools/dist/build/CabalInspector/CabalInspector')
+    CABAL_INSPECTOR_EXE_PATH = os.path.join(cache_path, 'tools/bin/CabalInspector')
     preload_settings()
 
 if int(sublime.version()) < 3000:


### PR DESCRIPTION
This series of commits makes the ModuleInspector and CabalInspector compile with recent versions of GHC, Cabal, haskell-src-exts, haskell-api and haskell-library.