### PR TITLE
syntax: allow primes in names

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.tmLanguage
+++ b/Syntaxes/Haskell-SublimeHaskell.tmLanguage
@@ -371,7 +371,7 @@
 			<string>(?x)
 			(')
 			(?:
-				[\ -\[\]-~]								# Basic Char
+				[\ -&(-\[\]-~]								# Basic Char
 			  | (\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE
 					|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS
 					|US|SP|DEL|[abfnrtv\\\"'\&amp;]))		# Escapes


### PR DESCRIPTION
`'''` is not a valid character in Haskell, so dropped `'` from the set.
This patch makes the colouring of the following snippet correct:

    main = do
        bar
        bar'
        bar''
        bar'''
        bar''''
        bar'''''