### PR TITLE
Fixes #254

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.tmLanguage
+++ b/Syntaxes/Haskell-SublimeHaskell.tmLanguage
@@ -520,7 +520,7 @@
 					<string>(?x)
 					(')
 					(?:
-						[\ -&(-\[\]-~]								# Basic Char
+						[\ -&(-\[\]-~"]								# Basic Char
 					  | (\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE
 							|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS
 							|US|SP|DEL|[abfnrtv\\\"'\&amp;]))		# Escapes


### PR DESCRIPTION
I am not 100% sure if this is the right place for this change, but adding a double quote in the basic char set fixes #254. The escapes section only allows escaped double quotes.