### PR TITLE
Fix several issues with Haskell syntax highlighting

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.tmLanguage
+++ b/Syntaxes/Haskell-SublimeHaskell.tmLanguage
@@ -741,9 +741,9 @@
 		<key>infix_function_definition</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(?=(([\w'\.'"]+|\(.*\)|\[.*\])\s+)+([^\w\s'"`\(\)]+|`[a-z][\w']*`).*=)</string>
+			<string>^\s*(?=(([\w'\.'"]+|(?:\w+@)?\(.*\)|\[.*\])\s+)+([^"'_,\(\);\[\]`\{\}\:\w\s]+|`[a-z][\w']*`)((\s*[\w'\.'"]+|\s*(?:\w+@)?\(.*\)|\s*\[.*\]))+\s*=)</string>
 			<key>end</key>
-			<string>([^\w\s\.'"`]+|`[a-z][\w']*`)</string>
+			<string>( [^"'_,\(\);\[\]`\{\}\:\w\s]+|`[a-z][\w']*`)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>

--- a/Syntaxes/Haskell-SublimeHaskell.tmLanguage
+++ b/Syntaxes/Haskell-SublimeHaskell.tmLanguage
@@ -709,7 +709,7 @@
 		<key>function_definition</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(?&lt;!')\b([a-z_][\w']*|\(\W+\))\s+(?![^\w\s='"\(\[])(?=(([\w\s\.,'"]*|\(.*\)|\[.*\])\s+)*=)</string>
+			<string>^\s*(?&lt;!')\b([a-z_][\w']*|\(\W+\))\s+(?![^\w\s='"\(\[])(?=((([\w\.,'"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*=))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/Syntaxes/Haskell-SublimeHaskell.tmLanguage
+++ b/Syntaxes/Haskell-SublimeHaskell.tmLanguage
@@ -709,7 +709,7 @@
 		<key>function_definition</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(?&lt;!')\b([a-z_][\w']*|\(\W+\))\s+(?![^\w\s='"\(\[])(?=((([\w\.,'"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*=))</string>
+			<string>^\s*(?&lt;!')\b([a-z_][\w']*|\(\W+\))\s+(?![^\w\s='"\(\[])(?=((([\w\.,'"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*[=\|]))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
This fixes several issues with highlighting.

**Functions using the "@" (Pattern-As) operator do not have their names matched properly.**

Before:
![before](https://cloud.githubusercontent.com/assets/12696953/14214976/c8d9743e-f848-11e5-91ce-ce4e66a14d79.png)

After:
![aftera](https://cloud.githubusercontent.com/assets/12696953/14214979/d07d57fa-f848-11e5-870d-2356c2d5c2ca.png)

**Function names with the guard expression are not matched. Don't really know if this was intended I just thought it would make sense to highlight them.**

After:
![afterb](https://cloud.githubusercontent.com/assets/12696953/14214985/d8444282-f848-11e5-97d8-c148f3c79a61.png)


**Incorrect detection of infix function definitions**

Before (See "Just (key,value)") :
![before_infix](https://cloud.githubusercontent.com/assets/12696953/14215021/08309824-f849-11e5-98c7-c5e9580fc628.png)

After:
![after_infix](https://cloud.githubusercontent.com/assets/12696953/14214996/e680d536-f848-11e5-9146-5818a9e9fdca.png)
