### PR TITLE
Fixed NameError for `can_complete_qualified_symbol`

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -101,7 +101,7 @@ class SublimeHaskellContext(sublime_plugin.EventListener):
             word_region = view.word(region)
             preline = get_line_contents_before_region(view, word_region)
             preline += chars[key]
-            return can_complete_qualified_symbol(get_qualified_symbol(preline))
+            return autocomplete.can_complete_qualified_symbol(get_qualified_symbol(preline))
         else:
             return False
 


### PR DESCRIPTION
As described in Issue #289 this package occasionally crashed with NameError for `can_complete_qualified_symbol`. The problem was that the code assumed that the name was imported into the global namespace, while actually only its' module was imported. This pull request fixes that bug by calling that function through its' fully qualified name.