### PR TITLE
ensure stderr and stdout go somewhere

### DIFF
--- a/Settings/SublimeHaskell.sublime-settings
+++ b/Settings/SublimeHaskell.sublime-settings
@@ -58,9 +58,13 @@
 	// Show error window on build/check/lint:
 	"show_error_window": true,
 
-	// Extra directories to be added to the front of the PATH environment variable.
-	// Specify this for using custom ghc, cabal, and ghc-mod
-	// Example: /home/user/.cabal/bin
+	// Extra directories to be added to the front of the PATH environment variable,
+	// if you don't have customary places where Haskell executables are installed,
+	// such as $HOME/.cabal/bin, $HOME/.local/bin (Unix) or %APPDATA%/local/bin on
+	// Windows.
+	//
+	// Note: You can use environment variables here, e.g., $HOME and %APPDATA%. Only
+	// "%something%" will work on Windows platforms.
 	"add_to_PATH": [],
 
 // Inhibit default Sublime word completions

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -340,13 +340,11 @@ class AutoCompletion(object):
             sandbox - get sandbox modules
         """
         if self.current_filename:
-            mods = hsdev.client.scope_modules(self.current_filename) or []
-            return set([m.name for m in mods])
+            return set([m.name for m in hsdev.client.scope_modules(self.current_filename)])
         elif current_dir:
             proj = hsdev.client.project(path = current_dir)
             if proj and 'path' in proj:
-                mods = hsdev.client.list_modules(deps = proj['path']) or []
-                return set([m.name for m in mods])
+                return set([m.name for m in hsdev.client.list_modules(deps = proj['path'])])
             sbox = hsdev.client.sandbox(path = current_dir)
             if sbox and type(sbox) == dict and 'sandbox' in sbox:
                 sbox = sbox.get('sandbox')

--- a/autocomplete.py
+++ b/autocomplete.py
@@ -340,18 +340,22 @@ class AutoCompletion(object):
             sandbox - get sandbox modules
         """
         if self.current_filename:
-            return set([m.name for m in hsdev.client.scope_modules(self.current_filename)])
+            mods = hsdev.client.scope_modules(self.current_filename) or []
+            return set([m.name for m in mods])
         elif current_dir:
             proj = hsdev.client.project(path = current_dir)
             if proj and 'path' in proj:
-                return set([m.name for m in hsdev.client.list_modules(deps = proj['path'])])
+                mods = hsdev.client.list_modules(deps = proj['path']) or []
+                return set([m.name for m in mods])
             sbox = hsdev.client.sandbox(path = current_dir)
             if sbox and type(sbox) == dict and 'sandbox' in sbox:
                 sbox = sbox.get('sandbox')
             if sbox:
-                return set([m.name for m in hsdev.client.list_modules(sandbox = sbox)])
+                mods = hsdev.client.list_modules(sandbox = sbox) or []
+                return set([m.name for m in mods])
         else:
-            return set([m.name for m in hsdev.client.list_modules(cabal = True)])
+            mods = hsdev.client.list_modules(cabal = True) or []
+            return set([m.name for m in mods])
 
 autocompletion = AutoCompletion()
 

--- a/build.py
+++ b/build.py
@@ -343,11 +343,12 @@ class SublimeHaskellRunCommand(SublimeHaskellBaseCommand):
 
 def run_binary(name, bin_file, base_dir):
     with status_message_process('Running {0}'.format(name), priority = 5) as s:
-        exit_code, out, err = call_and_wait(bin_file, cwd=base_dir)
+        exit_code, out, err = ProcHelper.run_process(bin_file, cwd=base_dir)
         window = sublime.active_window()
         if not window:
             return
         if exit_code == 0:
+            s.ok()
             sublime.set_timeout(lambda: write_output(window, out, base_dir), 0)
         else:
             s.fail()

--- a/commands.py
+++ b/commands.py
@@ -621,7 +621,7 @@ class SublimeHaskellInsertImportForSymbol(hsdev.HsDevTextCommand):
         self.module_name = module_name
         contents = self.view.substr(sublime.Region(0, self.view.size()))
         contents_part = contents[0: list(re.finditer('^import.*$', contents, re.MULTILINE))[-1].end()]
-        call_and_wait_tool(['hsinspect'], 'hsinspect', contents_part, self.on_inspected, check_enabled = False)
+        ProcHelper.invoke_tool(['hsinspect'], 'hsinspect', contents_part, self.on_inspected, check_enabled = False)
 
     def on_inspected(self, result):
         cur_module = hsdev.parse_module(json.loads(result)['module']) if self.view.is_dirty() else head_of(hsdev.client.module(file = self.current_file_name))
@@ -678,8 +678,8 @@ class SublimeHaskellClearImports(hsdev.HsDevTextCommand):
 
         imports = sorted(cur_module.imports, key = lambda i: i.position.line)
 
-        cmd = ['hsclearimports', self.current_file_name, '--max-import-list', '16']
-        (exit_code, cleared, err) = call_and_wait(cmd)
+        cmd = ['hsclearimports', self.current_file_name, '--max-import-list', '32']
+        exit_code, cleared, err = ProcHelper.run_process(cmd)
         if exit_code != 0:
             log('hsclearimports error: {0}'.format(err), log_error)
             return

--- a/hsdev.py
+++ b/hsdev.py
@@ -117,12 +117,14 @@ def hsinspect(module = None, file = None, cabal = None, ghc_opts = []):
         cmd.extend(['-g', opt])
 
     with ProcHelper(cmd, 'hsinspect', lambda s: json.loads(s), file, None) as p:
-        if p is not None:
-            r = p.wait()
-            if 'error' in r:
-                log('hsinspect returns error: {0}'.format(r['error']), log_error)
+        if p.process is not None:
+            err_code, stdout, stderr = p.wait()
+            if 'error' in stdout:
+                log('hsinspect returns error: {0}'.format(stdout), log_error)
+            elif 'error' in stderr:
+                log('hsinspect returns error: {0}'.format(stderr), log_error)
             else:
-              return on_result(r) if on_result else r
+              return on_result(stdout) if on_result else stdout
     return None
 
 
@@ -139,15 +141,11 @@ def parse_database(s):
 
 
 def parse_decls(s):
-    if s is None:
-        return None
-    return [parse_module_declaration(decl) for decl in s]
+    return [parse_module_declaration(decl) for decl in s] if s is not None else []
 
 
 def parse_modules_brief(s):
-    if s is None:
-        return None
-    return [parse_module_id(m) for m in s]
+    return [parse_module_id(m) for m in s] if s is not None else []
 
 
 def get_value(dc, ks, defval = None):
@@ -260,9 +258,7 @@ def parse_declaration(decl):
 
 
 def parse_declarations(decls):
-    if decls is None:
-        return None
-    return [parse_declaration(d) for d in decls]
+    return [parse_declaration(d) for d in decls] if decls is not None else []
 
 
 def parse_module_declaration(d, parse_module_info = True):


### PR DESCRIPTION
Minor bug with hsdev interaction: Closing stdout and stderr after starting hsdev leaves a half-open pipe, sometimes causing hsdev to report errors because its children also see the half-open pipe.

All subprocess interaction is via pipes. There is no reason to redirect the subprocess' stdout and stderr anywhere else.

- The common use case is to call ProcHelper.wait() and retrieve the exit  code, stdout and stderr.

- The only other use case is starting helper servers, e.g., 'hsdev'.  In this use case, stdout is scanned for a specific startup message,  which precludes redirecting output to os.devnull. Once the startup  message appears, run two threads to continually drain the subprocess'  stdout and stderr to prevent a lock-up from a pipe buffer waiting to  have its output read.

Fix Bug: add_to_PATH didn't actually do anything because subprocess.Popen() does not use the augmented PATH to find the executable. It only passed the augmented environment to the subprocesses.

There are two options:

(a) Temporarily override os.environ['PATH'] so that subprocess.Popen() can actually find the executable.

(b) Actually find the executable by scanning the augmented path.

Option (b) is currently used. Moreover, if the executable is found, cache the mapping from tools to executable name to reduce the file system probing overhead.