### PR TITLE
Fixed cabal run

### DIFF
--- a/build.py
+++ b/build.py
@@ -343,7 +343,7 @@ class SublimeHaskellRunCommand(SublimeHaskellBaseCommand):
 
 def run_binary(name, bin_file, base_dir):
     with status_message_process('Running {0}'.format(name), priority = 5) as s:
-        exit_code, out, err = ProcHelper.run_process(bin_file, cwd=base_dir)
+        exit_code, out, err = ProcHelper.run_process([bin_file], cwd=base_dir)
         window = sublime.active_window()
         if not window:
             return


### PR DESCRIPTION
That's it. Cabal run wasn't working because ```ProcHelper.run_process``` wants a list of commands.