### PR TITLE
ProcHelper obj not being referenced correctly.

### DIFF
--- a/filter_command.py
+++ b/filter_command.py
@@ -30,7 +30,7 @@ class SublimeHaskellFilterCommand(SH.SublimeHaskellTextCommand):
                 # Newline conversion seems dubious here, but... leave it alone for the time being.
                 sel_str = self.view.substr(selection).replace('\r\n', '\n')
 
-                with ProcHelper(self.indenter, sel_str) as p:
+                with SH.ProcHelper(self.indenter, sel_str) as p:
                     if p.process is not None:
                         exit_code, out, err = p.wait()
                         # stylish-haskell does not have a non-zero exit code if it errors out! (Surprise!)


### PR DESCRIPTION
Heya,

I had an issue where my Stylish Haskell command stopped working, and it had errors in the console about being unable to find 'ProcHelper'. I went digging and noticed that the import for sublime_haskell in filter_command.py was using an alias 'SH' but that alias wasn't being used to reference ProcHelper. Thus...... the error.

Unsure if anyone else had encountered this or if it's been fixed in a different branch. :)