### PR TITLE
Fix KeyError for conflicting flag

### DIFF
--- a/check_lint.py
+++ b/check_lint.py
@@ -86,7 +86,7 @@ class SublimeHaskellHsDevChain(CommandWin.BackendTextCommand):
         output_messages = [ParseOutput.OutputMessage(m['source']['file'],
                                                      HsResultParse.parse_region(m['region']).to_zero_based(),
                                                      m['level'].capitalize() + ': ' + m['note']['message'].replace('\n', '\n  '),
-                                                     m['level']) for m in self.msgs]
+                                                     m['level']) for m in self.msgs if 'file' in m['source']]
 
         self.corrections = corrections or []
         for corr in self.corrections:


### PR DESCRIPTION
HLint will complain if a source file specifies a conflicting `-Ox` compiler flag, such as `{-# OPTIONS_GHC -O2 #-}`. However, the `source` key is just an empty object in this case and a `KeyError` is raised:
```javascript
{
  'level': 'warning',
  'note': {
    'message': '-O conflicts with --interactive; -O ignored.',
    'suggestion': None
  },
  'region': {
    'from': {
      'column': 0,
      'line': 0
    },
    'to': {
      'column': 0,
      'line': 0
    }
  },
  'source': {
  }
}
```

```
Exception in thread Thread-15:
Traceback (most recent call last):
  File "./python3.3/threading.py", line 901, in _bootstrap_inner
  File "./python3.3/threading.py", line 858, in run
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\hsdev\client.py", line 245, in receiver
    self.invoke_callbacks(resp, resp_id, requests)
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\hsdev\client.py", line 271, in invoke_callbacks
    callbacks.call_response(response['result'])
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\hsdev\callback.py", line 31, in call_response
    call_callback(self.on_response, resp)
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\hsdev\callback.py", line 11, in call_callback
    callback_fn(*args, **kwargs)
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\hsdev\client.py", line 308, in client_call_response
    HsCallback.call_callback(on_response, resp)
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\hsdev\callback.py", line 11, in call_callback
    callback_fn(*args, **kwargs)
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\hsdev\backend.py", line 269, in process_response
    on_response(on_result(resp))
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\check_lint.py", line 89, in on_autofix
    m['level']) for m in self.msgs]
  File "C:\Users\tr\AppData\Roaming\Sublime Text 3\Packages\SublimeHaskell\check_lint.py", line 89, in <listcomp>
    m['level']) for m in self.msgs]
KeyError: 'file'
```