### PR TITLE
Fix crashing backend and freezing issues

### DIFF
--- a/hsdev/backend.py
+++ b/hsdev/backend.py
@@ -519,8 +519,7 @@ class HsDevBackend(Backend.HaskellBackend):
     def flags(self, _projectname, **backend_args):
         return self.command('flags', {}, **backend_args)
 
-    def autofix_show(self, messages, **backend_args):
-        wait_complete = backend_args.get('wait_complete', False)
+    def autofix_show(self, messages, wait_complete=False, **backend_args):
         action = self.list_command if wait_complete else self.async_list_command
         return action('autofix show', {'messages': messages}, ResultParse.parse_corrections, **backend_args)
 


### PR DESCRIPTION
Fixes #371 

Putting back the `wait_complete` keyword in `autofix_show` seems to fix the freezing issues. At least it does for me.