### PR TITLE
Make command `GHCi REPL` always visible

### DIFF
--- a/repl.py
+++ b/repl.py
@@ -114,6 +114,9 @@ class SublimeHaskellReplGhciCommand(CommandWin.SublimeHaskellWindowCommand):
     def is_enabled(self):
         return HAS_SUBLIME_REPL
 
+    def is_visible(self):
+        return True
+
 
 class SublimeHaskellReplGhciCurrentFileCommand(CommandWin.SublimeHaskellWindowCommand):
     def run(self, **_kwargs):


### PR DESCRIPTION
Currently the option to open a GHCi REPL only appears in the command palette when the current view contains a Haskell file. As far I am aware, there is no need for this restriction. (I think this is how the options in the menu Tools/SublimeREPL/SublimeHaskell work.) So let's change it.