### PR TITLE
Rename custom syntax to "Haskell (improved)"

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.YAML-tmLanguage
+++ b/Syntaxes/Haskell-SublimeHaskell.YAML-tmLanguage
@@ -1,6 +1,6 @@
 ---
 # [PackageDev] target_format: plist, ext: tmLanguage
-name: Haskell
+name: Haskell (improved)
 scopeName: source.haskell
 fileTypes: [hs, hsc]
 uuid: 5C034675-1F6D-497E-8073-369D37E2FD7D

--- a/Syntaxes/Haskell-SublimeHaskell.tmLanguage
+++ b/Syntaxes/Haskell-SublimeHaskell.tmLanguage
@@ -10,7 +10,7 @@
 	<key>keyEquivalent</key>
 	<string>^~H</string>
 	<key>name</key>
-	<string>Haskell</string>
+	<string>Haskell (improved)</string>
 	<key>patterns</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This helps avoid the problem when the user needs to switch to the default syntax for whatever reason, but cannot select the right one from the list since both standard syntax and the one provided by SublimeHaskell share the same name:

![image](https://user-images.githubusercontent.com/1315874/35010711-da2f2848-fb14-11e7-8778-9dd3e449ff76.png)
