### PR TITLE
Prepare functions handling responses for unexpected types

### DIFF
--- a/autocomplete.py
+++ b/autocomplete.py
@@ -33,6 +33,8 @@ def sorted_completions(comps):
 
 
 def make_completions(suggestions):
+    if not isinstance(suggestions, list):
+        return []
     # return sorted_completions([s.suggest() for s in suggestions or []])
     return sorted([s.suggest() for s in suggestions or []])
 

--- a/internals/utils.py
+++ b/internals/utils.py
@@ -21,7 +21,7 @@ def encode_bytes(src):
 
 
 def head_of(lst):
-    return lst[0] if lst else None
+    return lst[0] if isinstance(lst, list) and lst else None
 
 
 def tool_enabled(feature):


### PR DESCRIPTION
The backend `call` function can return boolean True or False, where a list is
expected in normal circumstances. This can happen, for example, if the hsdev
process is killed. In such cases, the involved functions raise a TypeError.

This behaviour can be seen in the on-hover and completions handlers, upon
killing the hsdev process.