### PR TITLE
Fix syntax error with Python 3.5+

### DIFF
--- a/internals/utils.py
+++ b/internals/utils.py
@@ -75,8 +75,8 @@ class Worker(object, metaclass=Singleton):
             finally:
                 self.jobs.task_done()
 
-    def async(self, name, worker_fn, *args, **kwargs):
+    def run_async(self, name, worker_fn, *args, **kwargs):
         self.jobs.put((name, worker_fn, args, kwargs))
 
 def run_async(name, worker_fn, *args, **kwargs):
-    Worker().async(name, worker_fn, *args, **kwargs)
+    Worker().run_async(name, worker_fn, *args, **kwargs)


### PR DESCRIPTION
Since Python 3.5, async is a keyword so when I try to import SublimeHaskell in ST 4 console, it throws a SyntaxError because ST 4 console uses Python 3.8.