### PR TITLE
Fix quasiquoter syntax

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -461,6 +461,7 @@ contexts:
         4: entity.name.function.quasi-quoter.haskell
         5: keyword.operator.haskell punctuation.quasi-quoter.haskell
       push:
+        - meta_include_prototype: false
         - meta_scope: string.quoted.quasi.haskell
         - match: '(\|\])'
           captures:

--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -456,15 +456,15 @@ contexts:
   quasi_quote:
     - match: '(\[)(([A-Z]\w*\.)*)([a-z]\w*)?(\|)'
       captures:
-        1: punctuation.quasi-quoter.haskell keyword.operator.haskell
+        1: keyword.operator.haskell punctuation.quasi-quoter.haskell
         2: storage.module.haskell
         4: entity.name.function.haskell
-        5: punctuation.quasi-quoter.haskell keyword.operator.haskell
+        5: keyword.operator.haskell punctuation.quasi-quoter.haskell
       push:
         - meta_scope: string.quoted.quasi.haskell
         - match: '(\|\])'
           captures:
-            1: punctuation.quasi-quoter.haskell keyword.operator.haskell
+            1: keyword.operator.haskell punctuation.quasi-quoter.haskell
           pop: true
   record_declaration:
     - match: '(\{)(?!-)'

--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -454,11 +454,12 @@ contexts:
           scope: entity.name.function.haskell
         - include: expression_stuff
   quasi_quote:
-    - match: '(\[)([a-z]\w*)?(\|)'
+    - match: '(\[)(([A-Z]\w*\.)*)([a-z]\w*)?(\|)'
       captures:
         1: punctuation.quasi-quoter.haskell keyword.operator.haskell
-        2: entity.name.function.haskell
-        3: punctuation.quasi-quoter.haskell keyword.operator.haskell
+        2: storage.module.haskell
+        4: entity.name.function.haskell
+        5: punctuation.quasi-quoter.haskell keyword.operator.haskell
       push:
         - meta_scope: string.quoted.quasi.haskell
         - match: '(\|\])'

--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -457,8 +457,8 @@ contexts:
     - match: '(\[)(([A-Z]\w*\.)*)([a-z]\w*)?(\|)'
       captures:
         1: keyword.operator.haskell punctuation.quasi-quoter.haskell
-        2: storage.module.haskell
-        4: entity.name.function.haskell
+        2: storage.module.quasi-quoter.haskell
+        4: entity.name.function.quasi-quoter.haskell
         5: keyword.operator.haskell punctuation.quasi-quoter.haskell
       push:
         - meta_scope: string.quoted.quasi.haskell

--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -215,6 +215,7 @@ contexts:
     - match: \b(error|undefined)\b
       scope: support.function.prelude.haskell
     - include: infix_op
+    - include: quasi_quote
     - match: '\[|\]'
       comment: List
       scope: keyword.operator.haskell punctuation.list.haskell
@@ -249,7 +250,6 @@ contexts:
     - include: prelude_names
     - include: common_keywords
     - include: literals
-    - include: quasi_quote
     - include: ctor_names
 
   field_signature:

--- a/Themes/Hasky (Dark).tmTheme
+++ b/Themes/Hasky (Dark).tmTheme
@@ -410,7 +410,29 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#87B42D</string>
+				<string>#BFA72F</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Quasi-quoter module qualifier</string>
+			<key>scope</key>
+			<string>storage.module.quasi-quoter.haskell</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#BFA72F</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Quasi-quoter function</string>
+			<key>scope</key>
+			<string>entity.name.function.quasi-quoter.haskell</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#BFA72F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -421,7 +443,7 @@ Find more themes at : https://github.com/daylerees/colour-schemes
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#87B42D</string>
+				<string>#BF5FBF</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

It's been bothering me that quasiquotes don't seem to be highlighted correctly. This should fix it and style the quasiquotes more meaningfully

![Screen Shot 2021-03-12 at 1 50 42 PM](https://user-images.githubusercontent.com/27799541/111002254-f57e4600-8339-11eb-8233-e1b10031c260.png)
