### PR TITLE
Prevent keywords from matching as a function

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -293,9 +293,9 @@ contexts:
     - include: fixity_declaration
 
   function_definition:
-    - match: '^\s*(?!let|in)({{var_id}}|\({{type_id}}\))\s+(?![^\w\s=''"\(\[])(?=((([\w\.,''"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*))'
+    - match: '^\s*(?!\b(let|in)\b)({{var_id}}|\({{type_id}}\))\s+(?![^\w\s=''"\(\[])(?=((([\w\.,''"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*))'
       captures:
-        1: entity.name.function.haskell
+        2: entity.name.function.haskell
       push:
         - meta_scope: meta.definition.function.haskell
         - match: '=|\|'
@@ -304,9 +304,9 @@ contexts:
         - include: expression_stuff
 
   function_signature:
-    - match: '^(\s*)(?!--|let|in)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
+    - match: '^(\s*)(?!--|\b(let|in)\b)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
       captures:
-        2: entity.name.function.haskell
+        3: entity.name.function.haskell
       push:
         - meta_scope: meta.declaration.function.haskell
         - match: '^(?!\1\s)|(?=})'

--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -293,7 +293,7 @@ contexts:
     - include: fixity_declaration
 
   function_definition:
-    - match: '^\s*({{var_id}}|\({{type_id}}\))\s+(?![^\w\s=''"\(\[])(?=((([\w\.,''"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*))'
+    - match: '^\s*(?!let|in)({{var_id}}|\({{type_id}}\))\s+(?![^\w\s=''"\(\[])(?=((([\w\.,''"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*))'
       captures:
         1: entity.name.function.haskell
       push:
@@ -304,7 +304,7 @@ contexts:
         - include: expression_stuff
 
   function_signature:
-    - match: '^(\s*)(?!--)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
+    - match: '^(\s*)(?!--|let|in)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
       captures:
         2: entity.name.function.haskell
       push:

--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -293,7 +293,7 @@ contexts:
     - include: fixity_declaration
 
   function_definition:
-    - match: '^\s*(?!\b(let|in|case)\b)({{var_id}}|\({{type_id}}\))\s+(?![^\w\s=''"\(\[])(?=((([\w\.,''"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*))'
+    - match: '^\s*(?!\b(let|in|case|where)\b)({{var_id}}|\({{type_id}}\))\s+(?![^\w\s=''"\(\[])(?=((([\w\.,''"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*))'
       captures:
         2: entity.name.function.haskell
       push:
@@ -304,7 +304,7 @@ contexts:
         - include: expression_stuff
 
   function_signature:
-    - match: '^(\s*)(?!--|\b(let|in|case)\b)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
+    - match: '^(\s*)(?!--|\b(let|in|case|where)\b)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
       captures:
         3: entity.name.function.haskell
       push:

--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -293,7 +293,7 @@ contexts:
     - include: fixity_declaration
 
   function_definition:
-    - match: '^\s*(?!\b(let|in)\b)({{var_id}}|\({{type_id}}\))\s+(?![^\w\s=''"\(\[])(?=((([\w\.,''"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*))'
+    - match: '^\s*(?!\b(let|in|case)\b)({{var_id}}|\({{type_id}}\))\s+(?![^\w\s=''"\(\[])(?=((([\w\.,''"_]+|(?:\w+\@)?\(.*\)|\[.*\])\s+)*))'
       captures:
         2: entity.name.function.haskell
       push:
@@ -304,7 +304,7 @@ contexts:
         - include: expression_stuff
 
   function_signature:
-    - match: '^(\s*)(?!--|\b(let|in)\b)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
+    - match: '^(\s*)(?!--|\b(let|in|case)\b)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
       captures:
         3: entity.name.function.haskell
       push:


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

Quick hack to fix
![Screen Shot 2021-09-01 at 5 47 46 PM](https://user-images.githubusercontent.com/27799541/131764008-39f08f96-f740-4827-aac1-8beadefb640d.png)

result:
![Screen Shot 2021-09-01 at 5 47 54 PM](https://user-images.githubusercontent.com/27799541/131764017-f7276276-4916-4d7b-95fa-18eec8af0175.png)

There's probably a better way to do this. If there's a better fix that's fairly straightforward, I'm happy to change it. Otherwise, this is a hacky solution that fixes the immediate issue