### PR TITLE
Fix function signatures

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -304,7 +304,7 @@ contexts:
         - include: expression_stuff
 
   function_signature:
-    - match: '^(\s*)(?!--|\b(let|in|case|where)\b)(?:(\(\W+\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
+    - match: '^(\s*)(?!--|\b(let|in|case|where)\b)(?:(\(\W+\)|[\w'']+))(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
       captures:
         3: entity.name.function.haskell
       push:

--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -304,7 +304,7 @@ contexts:
         - include: expression_stuff
 
   function_signature:
-    - match: '^(\s*)(?!--|\b(let|in|case|where)\b)(?:(\(\W\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
+    - match: '^(\s*)(?!--|\b(let|in|case|where)\b)(?:(\(\W+\)|[\w'']+)|[\(\[])(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
       captures:
         3: entity.name.function.haskell
       push:


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

Before:
<img width="208" alt="Screen Shot 2022-08-30 at 4 40 43 PM" src="https://user-images.githubusercontent.com/27799541/187562532-293a7c80-4cf6-4754-8f10-15f3477297c9.png">

After:
<img width="199" alt="Screen Shot 2022-08-30 at 4 41 11 PM" src="https://user-images.githubusercontent.com/27799541/187562542-637a09ff-59fc-4992-994a-f95b2271290f.png">

This doesn't fully support ScopedTypeVariables (the type annotation isn't recognized as a type), but at least it doesn't wreck the styling of the RHS.