### PR TITLE
Restrict regex for matching function signatures

### DIFF
--- a/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
+++ b/Syntaxes/Haskell-SublimeHaskell.sublime-syntax
@@ -304,7 +304,7 @@ contexts:
         - include: expression_stuff
 
   function_signature:
-    - match: '^(\s*)(?!--|\b(let|in|case|where)\b)(?:(\(\W+\)|[\w'']+))(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
+    - match: '^(\s*)(?!--|\b(let|in|case|where)\b)(?:(\(\W+\)|[a-z_''][\w'']*))(?=[\w'',\s\[\]\(\)]*(?:\s*)((?:::)|\u2237))'
       captures:
         3: entity.name.function.haskell
       push:


### PR DESCRIPTION
Before:
![Screen Shot 2022-11-03 at 5 33 08 PM](https://user-images.githubusercontent.com/6827922/199860351-d2aea12d-835b-4a48-adaf-cbabb11b7b08.png)
After:
![Screen Shot 2022-11-03 at 5 33 24 PM](https://user-images.githubusercontent.com/6827922/199860352-18b03685-a80c-4e4e-8e89-4fd440ea93c2.png)

Notice how in the before, invalid function names (like those starting with an apostrophe or with an upper case letter) were matched. But more urgently, it erroneously matched inline type annotations using ScopedTypeVariables.

Now, we restrict the regex to only allow functions to start with a lowercase letter or underscore. Notice that now, the ScopedTypeVariables syntax now less wrong (it still doesn't highlight the RHS as a Type, but at least it doesn't mess up the whole line)